### PR TITLE
Add extended dataset with favorite highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Student Distribution</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Student Distribution</h1>
+        <label for="classCount">Number of classes:</label>
+        <input type="number" id="classCount" min="1" value="2">
+        <button id="run">Distribute</button>
+        <div id="output" class="output"></div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,717 @@
+const students =
+[
+  {
+    "id": 1,
+    "firstName": "Anna",
+    "lastName": "Müller",
+    "gender": "F",
+    "favorite": 2
+  },
+  {
+    "id": 2,
+    "firstName": "Ben",
+    "lastName": "Schmidt",
+    "gender": "M",
+    "favorite": 1
+  },
+  {
+    "id": 3,
+    "firstName": "Clara",
+    "lastName": "Schneider",
+    "gender": "F",
+    "favorite": 4
+  },
+  {
+    "id": 4,
+    "firstName": "David",
+    "lastName": "Fischer",
+    "gender": "M",
+    "favorite": 3
+  },
+  {
+    "id": 5,
+    "firstName": "Eva",
+    "lastName": "Weber",
+    "gender": "F",
+    "favorite": 6
+  },
+  {
+    "id": 6,
+    "firstName": "Felix",
+    "lastName": "Meyer",
+    "gender": "M",
+    "favorite": 5
+  },
+  {
+    "id": 7,
+    "firstName": "Greta",
+    "lastName": "Wagner",
+    "gender": "F",
+    "favorite": 8
+  },
+  {
+    "id": 8,
+    "firstName": "Hans",
+    "lastName": "Becker",
+    "gender": "M",
+    "favorite": 7
+  },
+  {
+    "id": 9,
+    "firstName": "Ida",
+    "lastName": "Hoffmann",
+    "gender": "F",
+    "favorite": 10
+  },
+  {
+    "id": 10,
+    "firstName": "Jonas",
+    "lastName": "Schulz",
+    "gender": "M",
+    "favorite": 9
+  },
+  {
+    "id": 11,
+    "firstName": "Katrin",
+    "lastName": "Braun",
+    "gender": "F",
+    "favorite": 12
+  },
+  {
+    "id": 12,
+    "firstName": "Lukas",
+    "lastName": "Richter",
+    "gender": "M",
+    "favorite": 11
+  },
+  {
+    "id": 13,
+    "firstName": "Marie",
+    "lastName": "Klein",
+    "gender": "F",
+    "favorite": 14
+  },
+  {
+    "id": 14,
+    "firstName": "Niklas",
+    "lastName": "Wolf",
+    "gender": "M",
+    "favorite": 13
+  },
+  {
+    "id": 15,
+    "firstName": "Oliver",
+    "lastName": "Schröder",
+    "gender": "M",
+    "favorite": 16
+  },
+  {
+    "id": 16,
+    "firstName": "Paula",
+    "lastName": "Neumann",
+    "gender": "F",
+    "favorite": 15
+  },
+  {
+    "id": 17,
+    "firstName": "Quentin",
+    "lastName": "Schwarz",
+    "gender": "M",
+    "favorite": 18
+  },
+  {
+    "id": 18,
+    "firstName": "Rita",
+    "lastName": "Zimmermann",
+    "gender": "F",
+    "favorite": 17
+  },
+  {
+    "id": 19,
+    "firstName": "Simon",
+    "lastName": "Krüger",
+    "gender": "M",
+    "favorite": 20
+  },
+  {
+    "id": 20,
+    "firstName": "Tim",
+    "lastName": "Hartmann",
+    "gender": "M",
+    "favorite": 19
+  },
+  {
+    "id": 21,
+    "firstName": "Ute",
+    "lastName": "Lange",
+    "gender": "F",
+    "favorite": 22
+  },
+  {
+    "id": 22,
+    "firstName": "Verena",
+    "lastName": "Werner",
+    "gender": "F",
+    "favorite": 21
+  },
+  {
+    "id": 23,
+    "firstName": "Wolfgang",
+    "lastName": "Krause",
+    "gender": "M",
+    "favorite": 24
+  },
+  {
+    "id": 24,
+    "firstName": "Xaver",
+    "lastName": "Herrmann",
+    "gender": "M",
+    "favorite": 23
+  },
+  {
+    "id": 25,
+    "firstName": "Yvonne",
+    "lastName": "Walter",
+    "gender": "F",
+    "favorite": 26
+  },
+  {
+    "id": 26,
+    "firstName": "Zoe",
+    "lastName": "König",
+    "gender": "F",
+    "favorite": 25
+  },
+  {
+    "id": 27,
+    "firstName": "Adrian",
+    "lastName": "Mayer",
+    "gender": "M",
+    "favorite": 28
+  },
+  {
+    "id": 28,
+    "firstName": "Birgit",
+    "lastName": "Huber",
+    "gender": "F",
+    "favorite": 27
+  },
+  {
+    "id": 29,
+    "firstName": "Carsten",
+    "lastName": "Kaiser",
+    "gender": "M",
+    "favorite": 30
+  },
+  {
+    "id": 30,
+    "firstName": "Daniela",
+    "lastName": "Fuchs",
+    "gender": "F",
+    "favorite": 29
+  },
+  {
+    "id": 31,
+    "firstName": "Emil",
+    "lastName": "Pohl",
+    "gender": "M",
+    "favorite": 30
+  },
+  {
+    "id": 32,
+    "firstName": "Friederike",
+    "lastName": "Franke",
+    "gender": "F",
+    "favorite": 31
+  },
+  {
+    "id": 33,
+    "firstName": "Gregor",
+    "lastName": "Berger",
+    "gender": "M",
+    "favorite": 32
+  },
+  {
+    "id": 34,
+    "firstName": "Heidi",
+    "lastName": "Winkler",
+    "gender": "F",
+    "favorite": 33
+  },
+  {
+    "id": 35,
+    "firstName": "Ingo",
+    "lastName": "Schmitt",
+    "gender": "M",
+    "favorite": 34
+  },
+  {
+    "id": 36,
+    "firstName": "Judith",
+    "lastName": "Jakob",
+    "gender": "F",
+    "favorite": 35
+  },
+  {
+    "id": 37,
+    "firstName": "Klaus",
+    "lastName": "Lorenz",
+    "gender": "M",
+    "favorite": 36
+  },
+  {
+    "id": 38,
+    "firstName": "Lena",
+    "lastName": "Heinrich",
+    "gender": "F",
+    "favorite": 37
+  },
+  {
+    "id": 39,
+    "firstName": "Martin",
+    "lastName": "Dietrich",
+    "gender": "M",
+    "favorite": 38
+  },
+  {
+    "id": 40,
+    "firstName": "Nora",
+    "lastName": "Schumacher",
+    "gender": "F",
+    "favorite": 39
+  },
+  {
+    "id": 41,
+    "firstName": "Otto",
+    "lastName": "Ludwig",
+    "gender": "M",
+    "favorite": 40
+  },
+  {
+    "id": 42,
+    "firstName": "Petra",
+    "lastName": "Simon",
+    "gender": "F",
+    "favorite": 41
+  },
+  {
+    "id": 43,
+    "firstName": "Ralf",
+    "lastName": "Böhm",
+    "gender": "M",
+    "favorite": 42
+  },
+  {
+    "id": 44,
+    "firstName": "Stefanie",
+    "lastName": "Schubert",
+    "gender": "F",
+    "favorite": 43
+  },
+  {
+    "id": 45,
+    "firstName": "Tobias",
+    "lastName": "Winter",
+    "gender": "M",
+    "favorite": 44
+  },
+  {
+    "id": 46,
+    "firstName": "Ulrich",
+    "lastName": "Arnold",
+    "gender": "M",
+    "favorite": 45
+  },
+  {
+    "id": 47,
+    "firstName": "Viktoria",
+    "lastName": "Kramer",
+    "gender": "F",
+    "favorite": 46
+  },
+  {
+    "id": 48,
+    "firstName": "Walter",
+    "lastName": "Ott",
+    "gender": "M",
+    "favorite": 47
+  },
+  {
+    "id": 49,
+    "firstName": "Xavier",
+    "lastName": "Voigt",
+    "gender": "M",
+    "favorite": 48
+  },
+  {
+    "id": 50,
+    "firstName": "Yara",
+    "lastName": "Walther",
+    "gender": "F",
+    "favorite": 49
+  },
+  {
+    "id": 51,
+    "firstName": "Zoltan",
+    "lastName": "Paulsen",
+    "gender": "M",
+    "favorite": 50
+  },
+  {
+    "id": 52,
+    "firstName": "Andreas",
+    "lastName": "Seidel",
+    "gender": "M",
+    "favorite": 51
+  },
+  {
+    "id": 53,
+    "firstName": "Bernd",
+    "lastName": "Bender",
+    "gender": "M",
+    "favorite": 52
+  },
+  {
+    "id": 54,
+    "firstName": "Christa",
+    "lastName": "Ebel",
+    "gender": "F",
+    "favorite": 53
+  },
+  {
+    "id": 55,
+    "firstName": "Dirk",
+    "lastName": "Bauer",
+    "gender": "M",
+    "favorite": 54
+  },
+  {
+    "id": 56,
+    "firstName": "Esther",
+    "lastName": "Götz",
+    "gender": "F",
+    "favorite": 55
+  },
+  {
+    "id": 57,
+    "firstName": "Florian",
+    "lastName": "Hahn",
+    "gender": "M",
+    "favorite": 56
+  },
+  {
+    "id": 58,
+    "firstName": "Gabi",
+    "lastName": "Seifert",
+    "gender": "F",
+    "favorite": 57
+  },
+  {
+    "id": 59,
+    "firstName": "Herbert",
+    "lastName": "Horn",
+    "gender": "M",
+    "favorite": 58
+  },
+  {
+    "id": 60,
+    "firstName": "Ilse",
+    "lastName": "Vogel",
+    "gender": "F",
+    "favorite": 59
+  },
+  {
+    "id": 61,
+    "firstName": "Jan",
+    "lastName": "Busch",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 62,
+    "firstName": "Kerstin",
+    "lastName": "Peter",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 63,
+    "firstName": "Lorenz",
+    "lastName": "Schilling",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 64,
+    "firstName": "Manuela",
+    "lastName": "Graf",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 65,
+    "firstName": "Norbert",
+    "lastName": "Seitz",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 66,
+    "firstName": "Olaf",
+    "lastName": "Kirchner",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 67,
+    "firstName": "Pauline",
+    "lastName": "Lange",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 68,
+    "firstName": "Roland",
+    "lastName": "Jäger",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 69,
+    "firstName": "Sabrina",
+    "lastName": "Vogelmann",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 70,
+    "firstName": "Thorsten",
+    "lastName": "Baumann",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 71,
+    "firstName": "Ursula",
+    "lastName": "Schwan",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 72,
+    "firstName": "Volkmar",
+    "lastName": "Heine",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 73,
+    "firstName": "Wiebke",
+    "lastName": "Eckert",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 74,
+    "firstName": "Xenia",
+    "lastName": "Konrad",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 75,
+    "firstName": "Yannic",
+    "lastName": "Peters",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 76,
+    "firstName": "Zacharias",
+    "lastName": "Brockmann",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 77,
+    "firstName": "Anton",
+    "lastName": "Heß",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 78,
+    "firstName": "Bastian",
+    "lastName": "Klug",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 79,
+    "firstName": "Constanze",
+    "lastName": "Friedrich",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 80,
+    "firstName": "Detlef",
+    "lastName": "Kuhn",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 81,
+    "firstName": "Enrico",
+    "lastName": "Geiger",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 82,
+    "firstName": "Ferdinand",
+    "lastName": "Grund",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 83,
+    "firstName": "Gudrun",
+    "lastName": "Stark",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 84,
+    "firstName": "Holger",
+    "lastName": "Greiner",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 85,
+    "firstName": "Isabell",
+    "lastName": "Schulze",
+    "gender": "F",
+    "favorite": null
+  },
+  {
+    "id": 86,
+    "firstName": "Jörg",
+    "lastName": "Kleine",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 87,
+    "firstName": "Kim",
+    "lastName": "Liebig",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 88,
+    "firstName": "Lutz",
+    "lastName": "Löwe",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 89,
+    "firstName": "Maximilian",
+    "lastName": "Lehmann",
+    "gender": "M",
+    "favorite": null
+  },
+  {
+    "id": 90,
+    "firstName": "Nadine",
+    "lastName": "Ziegler",
+    "gender": "F",
+    "favorite": null
+  }
+];
+const idMap = new Map(students.map(s => [s.id, s]));
+function findLeastPopulatedClass(classes) {
+  let minIdx = 0;
+  for (let i = 1; i < classes.length; i++) {
+    if (classes[i].length < classes[minIdx].length) {
+      minIdx = i;
+    }
+  }
+  return minIdx;
+}
+
+function distributeStudents(students, numClasses) {
+  const classes = Array.from({ length: numClasses }, () => []);
+  const assigned = new Set();
+
+  // Place mutual favorites first
+  for (const student of students) {
+    if (!assigned.has(student.id) && student.favorite) {
+      const fav = idMap.get(student.favorite);
+      if (fav && fav.favorite === student.id && !assigned.has(fav.id)) {
+        const idx = findLeastPopulatedClass(classes);
+        classes[idx].push(student, fav);
+        assigned.add(student.id);
+        assigned.add(fav.id);
+      }
+    }
+  }
+
+  // Place one-sided favorites if possible
+  for (const student of students) {
+    if (!assigned.has(student.id) && student.favorite) {
+      const favClassIndex = classes.findIndex(c => c.some(s => s.id === student.favorite));
+      if (favClassIndex !== -1) {
+        classes[favClassIndex].push(student);
+        assigned.add(student.id);
+      }
+    }
+  }
+
+  // Distribute remaining students evenly
+  for (const student of students) {
+    if (!assigned.has(student.id)) {
+      const idx = findLeastPopulatedClass(classes);
+      classes[idx].push(student);
+      assigned.add(student.id);
+    }
+  }
+
+  return classes;
+}
+
+function displayClasses(classes) {
+  const output = document.getElementById('output');
+  output.innerHTML = '';
+  classes.forEach((cls, index) => {
+    const div = document.createElement('div');
+    div.className = 'class-group';
+    const heading = document.createElement('h2');
+    heading.textContent = `Class ${index + 1}`;
+    div.appendChild(heading);
+    const list = document.createElement('ul');
+    cls.forEach(s => {
+      const li = document.createElement('li');
+      const fav = s.favorite ? idMap.get(s.favorite) : null;
+      const favName = fav ? `${fav.firstName} ${fav.lastName}` : 'none';
+      if (fav) {
+        const sameClass = cls.some(st => st.id === fav.id);
+        li.className = sameClass ? 'favorite-met' : 'favorite-missed';
+      }
+      li.textContent = `${s.firstName} ${s.lastName} - Favorite: ${favName}`;
+      list.appendChild(li);
+    });
+    div.appendChild(list);
+    output.appendChild(div);
+  });
+}
+
+document.getElementById('run').addEventListener('click', () => {
+  const num = parseInt(document.getElementById('classCount').value, 10);
+  if (num > 0) {
+    const result = distributeStudents(students, num);
+    displayClasses(result);
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f9f9f9;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 800px;
+    margin: 40px auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.output {
+    margin-top: 20px;
+}
+
+.class-group {
+    margin-bottom: 20px;
+}
+
+.class-group h2 {
+    margin-bottom: 10px;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 4px;
+}
+
+.favorite-met {
+    color: green;
+}
+
+.favorite-missed {
+    color: red;
+}


### PR DESCRIPTION
## Summary
- generate ~90 sample students with mostly German names
- show each student's favorite and highlight if placed together
- add CSS styles for success and failure indicators

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840b223aca48320aba1e4bb2b8001c2